### PR TITLE
Adds periods to list items — Design Affordance Controls

### DIFF
--- a/blog/DesignAffordanceControls.html
+++ b/blog/DesignAffordanceControls.html
@@ -409,12 +409,12 @@ America (art for sale)</a></li>
     <p>However, consider this: Many UI toolkits outside the web have, at some point, explicitly defined some kind of control which could be described as "a container with scrollbars". In a way, this makes sense: When something is scrollable, there are several UI implications:</p>
 
     <ul>
-      <li>They paint scroll bars and mouse/touch afforances</li>
-      <li>They become part of the sequential focus order. </li>
-      <li>Standard keyboard control affordances for managing the scroll are added</li>
+      <li>They paint scroll bars and mouse/touch afforances.</li>
+      <li>They become part of the sequential focus order.</li>
+      <li>Standard keyboard control affordances for managing the scroll are added.</li>
       <li>There are events and UI states to track.</li>
-      <li>They might gain an affordance to become user-sizable</li>
-      <li>...and so on</li>
+      <li>They might gain an affordance to become user-sizable.</li>
+      <li>...and so on.</li>
     </ul>
 
       <p>On the web, we don't look at the problem that way.  There is no special "scroll container" element, nor even an ARIA role for it.  Instead, elements are, first, just "Good Semantic Content", and whether they are scrollable (or not) is considered a matter of, and subject to, the design.  Overflow, and affordances related to it, are decidedly presentational.</p>


### PR DESCRIPTION
This PR adds periods to the end of list items in your article, "Design Affordance Controls".

While having the article read to me by Siri, some of the list items were harder to understand because each item was read seamlessly into the next one, as tho they were the same sentence. The list items with periods were read to me clearly.